### PR TITLE
DOCSP-41455: Standardize Count Documents page

### DIFF
--- a/source/includes/read/count.kt
+++ b/source/includes/read/count.kt
@@ -1,0 +1,52 @@
+package org.example
+import com.mongodb.ConnectionString
+import com.mongodb.MongoClientSettings
+import com.mongodb.client.model.*
+import com.mongodb.client.model.Filters.*
+import com.mongodb.kotlin.client.MongoClient
+import org.bson.codecs.pojo.annotations.BsonId
+import org.bson.types.ObjectId
+
+// start-data-class
+data class Movie(
+    @BsonId
+    val id: ObjectId,
+    val title: String
+)
+// end-data-class
+
+fun main() {
+    val uri = "mongodb+srv://michael:Scrubs1996@testcluster.kmosy7d.mongodb.net/?retryWrites=true&w=majority"
+
+    val settings = MongoClientSettings.builder()
+        .applyConnectionString(ConnectionString(uri))
+        .retryWrites(true)
+        .build()
+
+    val mongoClient = MongoClient.create(settings)
+    val database = mongoClient.getDatabase("sample_mflix")
+    val collection = database.getCollection<Movie>("movies")
+
+    // start-count-all
+    println(collection.countDocuments())
+    // end-count-all
+
+    // start-count-query
+    println(collection.countDocuments(eq("year", "1930")))
+    // end-count-query
+
+    // start-count-options
+    val options = CountOptions().comment("Retrieving count")
+    collection.countDocuments(Filters.empty(), options)
+    // end-count-options
+
+    // start-estimated-count
+    print(collection.estimatedDocumentCount())
+    // end-estimated-count
+
+    // start-estimated-count-options
+    val options = EstimatedDocumentCountOptions().comment("Retrieving count")
+    collection.estimatedDocumentCount(options)
+    // end-estimated-count-options
+}
+

--- a/source/includes/read/count.kt
+++ b/source/includes/read/count.kt
@@ -1,4 +1,3 @@
-package org.example
 import com.mongodb.ConnectionString
 import com.mongodb.MongoClientSettings
 import com.mongodb.client.model.*

--- a/source/read/count.txt
+++ b/source/read/count.txt
@@ -31,6 +31,14 @@ database from the :atlas:`Atlas sample datasets </sample-data>`. To learn how to
 free MongoDB Atlas cluster and load the sample datasets, see the
 :atlas:`Get Started with Atlas </getting-started>` guide.
 
+The following {+language+} data class models the documents in this collection:
+
+.. literalinclude:: /includes/read/project.kt
+   :start-after: start-data-class
+   :end-before: end-data-class
+   :language: kotlin
+   :copyable:
+
 .. _kotlin-sync-accurate-count:
 
 Retrieve an Accurate Count
@@ -40,7 +48,7 @@ Use the ``countDocuments()`` method to count the number of documents that are in
 collection. To count the number of documents that match specified search
 critera, pass a query filter to the ``countDocuments()`` method.
 
-.. TODO: To learn more about specifying a query, see :ref:`kotlin-sync-specify-query`.
+To learn more about specifying a query, see :ref:`kotlin-sync-specify-query`.
 
 Count All Documents
 ~~~~~~~~~~~~~~~~~~~
@@ -50,10 +58,11 @@ with no arguments, as shown in the following example:
 
 .. io-code-block::
 
-   .. input::
+   .. input:: /includes/read/count.kt
+      :start-after: start-count-all
+      :end-before: end-count-all
       :language: kotlin
-
-      print(collection.countDocuments())
+      :dedent:
 
    .. output::
        :visible: false
@@ -69,10 +78,11 @@ in the ``movies`` collection that have a ``year`` field value equal to ``1930``:
 
 .. io-code-block::
 
-   .. input::
-       :language: kotlin
-
-       print(collection.countDocuments(eq("year", "1930")))
+   .. input:: /includes/read/count.kt
+      :start-after: start-count-query
+      :end-before: end-count-query
+      :language: kotlin
+      :dedent:
 
    .. output::
       :visible: false
@@ -99,30 +109,33 @@ The following table describes the options you can set to customize ``countDocume
      - Description
 
    * - ``comment``
-     - | A comment to attach to the operation.
+     - | Specifies a comment to attach to the operation.
    
    * - ``skip``
-     - | The number of documents to skip before returning results.
+     - | Sets the number of documents to skip before returning results.
 
    * - ``limit``
-     - | The maximum number of documents to count. Must be a positive integer.
+     - | Sets the maximum number of documents to count. Must be a positive integer.
 
    * - ``maxTime``
-     - | The maximum amount of time to allow the operation to run, in milliseconds.
+     - | Sets the maximum amount of time to allow the operation to run, in milliseconds.
 
    * - ``collation``
-     - | The collation to use for the operation.
+     - | Specifies the kind of language collation to use when sorting
+         results. For more information, see :manual:`Collation </reference/collation/#std-label-collation>`
+         in the {+mdb-server+} manual.
 
    * - ``hint``
-     - | Gets or sets the index to scan for documents.
+     - | Sets the index to scan for documents.
 
 The following example uses a ``CountOptions`` object to add a comment to the
 ``countDocuments()`` operation:
 
-.. code-block:: kotlin
-
-   val options = CountOptions().comment("Retrieving count")
-   collection.countDocuments(options)
+.. literalinclude:: /includes/read/count.kt
+   :start-after: start-count-options
+   :end-before: end-count-options
+   :language: kotlin
+   :dedent:
 
 .. _kotlin-sync-estimated-count:
 
@@ -137,10 +150,11 @@ The following example prints the estimated number of documents in a collection:
 
 .. io-code-block::
 
-   .. input::
+   .. input:: /includes/read/count.kt
+      :start-after: start-estimated-count
+      :end-before: end-estimated-count
       :language: kotlin
-
-      print(collection.estimatedDocumentCount())
+      :dedent:
 
    .. output::
        :visible: false
@@ -167,18 +181,19 @@ The following table describes the options you can set to customize ``estimatedDo
      - Description
 
    * - ``comment``
-     - | A comment to attach to the operation.
+     - | Specifies a comment to attach to the operation.
 
    * - ``maxTime``
-     - | The maximum amount of time to allow the operation to run, in milliseconds.
+     - | Specifies the maximum amount of time to allow the operation to run, in milliseconds.
 
 The following example uses an ``EstimatedDocumentCountOptions`` object to add a comment to
 the ``estimatedDocumentCount()`` operation:
 
-.. code-block:: kotlin
-
-   val options = EstimatedDocumentCountOptions().comment("Retrieving count")
-   collection.estimatedDocumentCount(options)
+.. literalinclude:: /includes/read/count.kt
+   :start-after: start-estimated-count-options
+   :end-before: end-estimated-count-options
+   :language: kotlin
+   :dedent:
 
 API Documentation
 -----------------

--- a/source/read/count.txt
+++ b/source/read/count.txt
@@ -33,7 +33,7 @@ free MongoDB Atlas cluster and load the sample datasets, see the
 
 The following {+language+} data class models the documents in this collection:
 
-.. literalinclude:: /includes/read/project.kt
+.. literalinclude:: /includes/read/count.kt
    :start-after: start-data-class
    :end-before: end-data-class
    :language: kotlin


### PR DESCRIPTION
Touching up a page I created earlier in the Kotlin Sync project to meet the standard we're setting with all the other pages.

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kotlin-sync/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-41455>
Staging - <https://preview-mongodbmcmorisi.gatsbyjs.io/kotlin-sync/DOCSP-41455-standardize-count/read/count/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
