### PR TITLE
DOCSP-47962 realized duplicate /docs in url redirect

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,5 +1,5 @@
 define: prefix docs/languages/kotlin/kotlin-sync-driver
-define: base https://www.mongodb.com/docs/${prefix}
+define: base https://www.mongodb.com/${prefix}
 define: versions v5.1 v5.2 v5.3 master
 
 symlink: current -> master


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kotlin-sync/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-47962>

Extension to the ticket: after fixing the base I realized the base had duplicate /docs, removed one /docs to make sure the URL works
### Staging Links


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
