### PR TITLE
[v5.5] DOCSP-49013 BOM Tip for Kotlin Sync (#99)

### DIFF
--- a/source/builders/builders-data-classes.txt
+++ b/source/builders/builders-data-classes.txt
@@ -49,6 +49,12 @@ To implement this functionality, you must add the
 ``mongodb-driver-kotlin-extensions`` dependency to your dependencies
 list.
 
+.. sharedinclude:: dbx/jvm/BOM-installation-tip.rst
+
+   .. replacement:: installation-guide
+
+      :ref:`Add the Driver Bill of Materials <kotlin-sync-get-started-install-bom>` step of the Get Started guide.
+
 Select from the following tabs to see how to add the extension
 dependency to your project by using the :guilabel:`Gradle` and
 :guilabel:`Maven` package managers:
@@ -64,7 +70,7 @@ dependency to your project by using the :guilabel:`Gradle` and
       .. code-block:: kotlin
          :caption: build.gradle.kts
  
-         implementation("org.mongodb:mongodb-driver-kotlin-extensions:{+full-version+}")
+         implementation("org.mongodb:mongodb-driver-kotlin-extensions")
 
    .. tab::
       :tabid: Maven
@@ -78,7 +84,6 @@ dependency to your project by using the :guilabel:`Gradle` and
          <dependency>
              <groupId>org.mongodb</groupId>
              <artifactId>mongodb-driver-kotlin-extensions</artifactId>
-             <version>{+full-version+}</version>
          </dependency>
 
 After you install the extensions dependency, you can use the extension

--- a/source/data-formats/bson.txt
+++ b/source/data-formats/bson.txt
@@ -60,6 +60,12 @@ For instructions on how to add the {+driver-long+} as a dependency to your proje
 :ref:`driver installation <kotlin-sync-download-install>` section of our Get Started
 guide.
 
+.. sharedinclude:: dbx/jvm/BOM-installation-tip.rst
+
+   .. replacement:: installation-guide
+
+      :ref:`Add the Driver Bill of Materials <kotlin-sync-get-started-install-bom>` step of the Get Started guide.
+
 We recommend that you use the `Maven <https://maven.apache.org/>`__ or
 `Gradle <https://gradle.org/>`__ build automation tool to manage your {+language+}
 project's dependencies. The following instructions detail the dependency declarations for

--- a/source/data-formats/serialization.txt
+++ b/source/data-formats/serialization.txt
@@ -65,6 +65,13 @@ application. To learn more about this library, see the
 `kotlinx.serialization GitHub repository
 <https://github.com/Kotlin/kotlinx.serialization>`__.
 
+.. sharedinclude:: dbx/jvm/BOM-installation-tip.rst
+
+   .. replacement:: installation-guide
+
+      :ref:`Add the Driver Bill of Materials <kotlin-sync-get-started-install-bom>` step of the Get Started guide.
+
+
 Select from the following tabs to see how to add the serialization
 dependencies to your project by using either :guilabel:`Gradle` or
 :guilabel:`Maven`:

--- a/source/includes/data-formats/bson-gradle-versioned.rst
+++ b/source/includes/data-formats/bson-gradle-versioned.rst
@@ -1,5 +1,5 @@
 .. code-block:: kotlin
 
    dependencies {
-      implementation("org.mongodb:bson:{+full-version+}")
+      implementation("org.mongodb:bson")
    }

--- a/source/includes/data-formats/bson-maven-versioned.rst
+++ b/source/includes/data-formats/bson-maven-versioned.rst
@@ -4,6 +4,5 @@
        <dependency>
            <groupId>org.mongodb</groupId>
            <artifactId>bson</artifactId>
-           <version>{+full-version+}</version>
        </dependency>
    </dependencies>

--- a/source/includes/data-formats/serialization-gradle-versioned.rst
+++ b/source/includes/data-formats/serialization-gradle-versioned.rst
@@ -2,4 +2,4 @@
    :caption: build.gradle.kts
 
    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:{+serialization-version+}")
-   implementation("org.mongodb:bson-kotlinx:{+full-version+}")
+   implementation("org.mongodb:bson-kotlinx")

--- a/source/includes/data-formats/serialization-maven-versioned.rst
+++ b/source/includes/data-formats/serialization-maven-versioned.rst
@@ -9,5 +9,4 @@
    <dependency>
        <groupId>org.mongodb</groupId>
        <artifactId>bson-kotlinx</artifactId>
-       <version>{+full-version+}</version>
    </dependency>

--- a/source/includes/security/crypt-gradle-versioned.rst
+++ b/source/includes/security/crypt-gradle-versioned.rst
@@ -1,5 +1,5 @@
 .. code-block:: groovy
 
    dependencies {
-      implementation("org.mongodb:mongodb-crypt:{+mongocrypt-version+}")
+      implementation("org.mongodb:mongodb-crypt")
    }

--- a/source/includes/security/crypt-maven-versioned.rst
+++ b/source/includes/security/crypt-maven-versioned.rst
@@ -4,6 +4,5 @@
        <dependency>
            <groupId>org.mongodb</groupId>
            <artifactId>mongodb-crypt</artifactId>
-           <version>{+mongocrypt-version+}</version>
        </dependency>
    </dependencies>

--- a/source/index.txt
+++ b/source/index.txt
@@ -25,7 +25,6 @@
    Run a Command </run-command>
    Monitoring </monitoring>
    Security </security>
-   In-Use Encryption </security/encrypt-fields>
    Compatibility </compatibility>
    Validate Driver Signatures </validate-signatures>
    What's New </whats-new>
@@ -94,12 +93,6 @@ Use Builders API
 ----------------
 
 Learn how to work with the builder operation helpers in the :ref:`kotlin-sync-builders` section.
-
-In-Use Encryption
------------------
-
-Learn how to use in-use encryption to encrypt your MongoDB data in the
-:ref:`In-Use Encryption <kotlin-sync-fle>` section.
 
 Compatibility
 -------------

--- a/source/security/authentication.txt
+++ b/source/security/authentication.txt
@@ -87,7 +87,7 @@ mechanism:
          :end-before: end-default-mongo-cred
          :dedent:
 
-You can also explicitly specify the `SCRAM-SHA-256`` authentication mechanism,
+You can also explicitly specify the ``SCRAM-SHA-256`` authentication mechanism,
 as shown in the following code snippets.
 
 Select the :guilabel:`Connection String` or the :guilabel:`MongoCredential`

--- a/source/security/encrypt-fields.txt
+++ b/source/security/encrypt-fields.txt
@@ -4,25 +4,32 @@
 
    .. replacement:: driver-specific-content
 
-      .. important:: Compatible Encryption Library Version
+      Compatible Encryption Library Version
+      -------------------------------------
 
-         The {+driver-short+} uses the `mongodb-crypt
-         <https://mvnrepository.com/artifact/org.mongodb/mongodb-crypt>`__
-         encryption library for in-use encryption. This driver version
-         is compatible with ``mongodb-crypt`` v{+mongocrypt-version+}.
+      The {+driver-short+} uses the `mongodb-crypt
+      <https://mvnrepository.com/artifact/org.mongodb/mongodb-crypt>`__
+      encryption library for in-use encryption. This driver version
+      is compatible with ``mongodb-crypt`` v{+mongocrypt-version+}.
 
-         Select from the following :guilabel:`Maven` and
-         :guilabel:`Gradle` tabs to see how to add the ``mongodb-crypt``
-         dependency to your project by using the specified manager:
-         
-         .. tabs::
-         
-            .. tab:: Maven
-               :tabid: maven-dependency
-         
-               .. include:: /includes/security/crypt-maven-versioned.rst
-         
-            .. tab:: Gradle
-               :tabid: gradle-dependency
-         
-               .. include:: /includes/security/crypt-gradle-versioned.rst
+      .. sharedinclude:: dbx/jvm/BOM-installation-tip.rst
+
+         .. replacement:: installation-guide
+
+            :ref:`Add the Driver Bill of Materials <kotlin-sync-get-started-install-bom>` step of the Get Started guide.
+
+      Select from the following :guilabel:`Maven` and
+      :guilabel:`Gradle` tabs to see how to add the ``mongodb-crypt``
+      dependency to your project by using the specified manager:
+      
+      .. tabs::
+      
+         .. tab:: Maven
+            :tabid: maven-dependency
+      
+            .. include:: /includes/security/crypt-maven-versioned.rst
+      
+         .. tab:: Gradle
+            :tabid: gradle-dependency
+      
+            .. include:: /includes/security/crypt-gradle-versioned.rst


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v5.5`:
 - [DOCSP-49013 BOM Tip for Kotlin Sync (#99)](https://github.com/mongodb/docs-kotlin-sync/pull/99)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)